### PR TITLE
feat(issue56): Добавить enum в роуты

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,9 @@
     "extends": [
         "plugin:react/recommended",
         "plugin:prettier/recommended",
-        "airbnb"
+        "airbnb",
+        "eslint:recommended",
+        "plugin:@typescript-eslint/recommended"
     ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
@@ -44,7 +46,18 @@
         "react/function-component-definition": [2, { "namedComponents": "arrow-function" }],
         "react/jsx-filename-extension": [1, { "extensions": [".ts", ".tsx"] }],
         "import/no-default-export": "error",
-        "prettier/prettier": "error"
+        "prettier/prettier": "error",
+        "@typescript-eslint/ban-types": [
+            "error",
+            {
+                "extendDefaults": true,
+                "types": {
+                    "{}": false
+                }
+            }
+        ],
+        "no-shadow": "off",
+        "@typescript-eslint/no-shadow": "error"
     },
     "settings": {
         "import/resolver": {

--- a/src/components/Form/types.ts
+++ b/src/components/Form/types.ts
@@ -1,5 +1,5 @@
 export type formProps = {
     fields: { type: string; title: string }[];
-    setData: Function;
+    setData: () => void;
     submit: JSX.Element;
 };

--- a/src/components/Input/types.ts
+++ b/src/components/Input/types.ts
@@ -4,6 +4,6 @@ export type inputProps = {
     type: string;
     title: string;
     value: string;
-    setValid: Function;
+    setValid: () => void;
     onChange: ChangeEventHandler<HTMLInputElement>;
 };

--- a/src/components/utils/Routes/Routes.tsx
+++ b/src/components/utils/Routes/Routes.tsx
@@ -4,19 +4,20 @@ import { HomePage } from 'src/pages/HomePage';
 import { NotFoundPage } from 'src/pages/NotFoundPage';
 import { ProfilePage } from 'src/pages/ProfilePage';
 import { RegisterPage } from 'src/pages/RegisterPage';
+import { PageLinks } from './types';
 
 export const Routes = (): JSX.Element => (
     <Switch>
-        <Route exact path="/">
+        <Route exact path={PageLinks.home}>
             <HomePage />
         </Route>
-        <Route exact path="/auth">
+        <Route exact path={PageLinks.auth}>
             <AuthPage />
         </Route>
-        <Route exact path="/register">
+        <Route exact path={PageLinks.register}>
             <RegisterPage />
         </Route>
-        <Route exact path="/profile">
+        <Route exact path={PageLinks.profile}>
             <ProfilePage />
         </Route>
         <Route>{NotFoundPage}</Route>

--- a/src/components/utils/Routes/types.ts
+++ b/src/components/utils/Routes/types.ts
@@ -1,0 +1,7 @@
+export const enum PageLinks {
+    home = '/',
+    auth = '/auth',
+    game = '/battleship',
+    register = '/register',
+    profile = '/profile',
+}


### PR DESCRIPTION
## Задача
Сделать ссылки через enum, чтобы писать так:
```jsx
//before
<NavLink to="/profile"></NavLink>

//after
<NavLink to={PageLinks.profile}></NavLink>
```

## Решение

- Добавил enum 
- Поправил eslint для enum. Была ошибка `is already declared in the upper scope on line 1 column 13 no-shadow`
